### PR TITLE
Add daily .zip docs release workflow

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,0 +1,90 @@
+name: Docs Release
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 6:00 AM UTC
+  workflow_dispatch:       # Allow manual trigger for first run after PR approval
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if docs have changed since last release
+        id: changes
+        run: |
+          # On manual dispatch (first run), always build
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "First run (manual dispatch) — building unconditionally."
+            exit 0
+          fi
+
+          # For scheduled runs, check if docs/ or html/docs/ changed in the last 24 hours
+          LAST_CHANGE=$(git log --since="24 hours ago" --format="%H" -- docs/ html/docs/ | head -1)
+          if [ -n "$LAST_CHANGE" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Changes detected in docs/ or html/docs/."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes detected — skipping release."
+          fi
+
+      - name: Set date tag
+        if: steps.changes.outputs.changed == 'true'
+        id: date
+        run: |
+          DATE=$(date -u +"%Y-%m-%d")
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+          echo "tag=v$DATE" >> "$GITHUB_OUTPUT"
+          echo "zip_name=Git-Going-With-Git-$DATE.zip" >> "$GITHUB_OUTPUT"
+
+      - name: Create zip of docs and html/docs
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          zip -r "${{ steps.date.outputs.zip_name }}" docs/ html/docs/
+
+      - name: Delete existing release for today if it exists
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          gh release delete "${{ steps.date.outputs.tag }}" --yes --cleanup-tag 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          gh release create "${{ steps.date.outputs.tag }}" \
+            "${{ steps.date.outputs.zip_name }}" \
+            --title "Docs Release ${{ steps.date.outputs.date }}" \
+            --notes "Daily docs release for ${{ steps.date.outputs.date }}. Contains docs/ (Markdown) and html/docs/ (HTML)." \
+            --latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean up old releases (keep last 10)
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          # List all releases sorted by date (newest first), skip the first 10
+          RELEASES_TO_DELETE=$(gh release list --limit 100 --json tagName,createdAt \
+            --jq 'sort_by(.createdAt) | reverse | .[10:] | .[].tagName' \
+            | grep -E '^v[0-9]{4}-[0-9]{2}-[0-9]{2}$' || true)
+
+          if [ -z "$RELEASES_TO_DELETE" ]; then
+            echo "No old releases to clean up."
+          else
+            for TAG in $RELEASES_TO_DELETE; do
+              echo "Deleting release $TAG..."
+              gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+            done
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: docs-release
+  cancel-in-progress: false
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -28,14 +28,21 @@ jobs:
             exit 0
           fi
 
-          # For scheduled runs, check if docs/ or html/docs/ changed in the last 24 hours
-          LAST_CHANGE=$(git log --since="24 hours ago" --format="%H" -- docs/ html/docs/ | head -1)
-          if [ -n "$LAST_CHANGE" ]; then
+          # For scheduled runs, compare against the last release tag
+          LAST_TAG=$(git tag --list 'v[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]' --sort=-version:refname | head -1)
+          if [ -z "$LAST_TAG" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Changes detected in docs/ or html/docs/."
+            echo "No previous release tag found — building unconditionally."
+            exit 0
+          fi
+
+          DIFF=$(git diff --name-only "$LAST_TAG"..HEAD -- docs/ html/docs/)
+          if [ -n "$DIFF" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Changes detected since $LAST_TAG in docs/ or html/docs/."
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No changes detected — skipping release."
+            echo "No changes since $LAST_TAG — skipping release."
           fi
 
       - name: Set date tag


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that creates daily zip releases of `docs/` (Markdown) and `html/docs/` (HTML)
- Runs on a daily schedule (6:00 AM UTC) with manual dispatch support for the initial run
- Detects changes before creating releases — skips if no docs content has changed
- Names zip files as `Git-Going-With-Git-yyyy-mm-dd.zip` with release tags `vyyyy-mm-dd`
- Marks each release as `latest` and retains only the 10 most recent releases

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` to verify first run
- [ ] Confirm zip contains both `docs/` and `html/docs/` folders
- [ ] Verify release tag format (`vyyyy-mm-dd`) and `latest` tag assignment
- [ ] Confirm no release is created when docs content is unchanged
- [ ] Verify old releases beyond 10 are cleaned up