### PR TITLE
Documentation should be updated to reflect Mac substitution of CMD fo…

### DIFF
--- a/docs/00-pre-workshop-setup.md
+++ b/docs/00-pre-workshop-setup.md
@@ -442,6 +442,9 @@ If you open Feature Preview and neither **"New Issues Experience"** nor **"New F
 - Press `Left Arrow + Right Arrow` simultaneously to toggle Quick Nav
 - With Quick Nav on: `H` = next heading, `L` = next link, `B` = next button (same as NVDA/JAWS browse mode keys)
 
+#### Quick note about VS Code keyboard commands as they relate to the Mac
+
+Throughout this documentation, Windows keyboard shortcuts for VS Code are frequently referenced.  In general, these keyboard shorccuts work on the Mac, however, Mac users should substitute `Command` whenever `ctrl` is referenced.  For example, Windows users might use the keyboard shortcut `CTRL+SHFT+P` to open the command palet. On the Mac, this keyboard shortcut would be `CMD+SHFT+P`.
 
 ### Browser Recommendations Summary
 

--- a/docs/00-pre-workshop-setup.md
+++ b/docs/00-pre-workshop-setup.md
@@ -442,9 +442,9 @@ If you open Feature Preview and neither **"New Issues Experience"** nor **"New F
 - Press `Left Arrow + Right Arrow` simultaneously to toggle Quick Nav
 - With Quick Nav on: `H` = next heading, `L` = next link, `B` = next button (same as NVDA/JAWS browse mode keys)
 
-#### Quick note about VS Code keyboard commands as they relate to the Mac
+#### A note for Mac users about keyboard shortcuts
 
-Throughout this documentation, Windows keyboard shortcuts for VS Code are frequently referenced.  In general, these keyboard shorccuts work on the Mac, however, Mac users should substitute `Command` whenever `ctrl` is referenced.  For example, Windows users might use the keyboard shortcut `CTRL+SHFT+P` to open the command palet. On the Mac, this keyboard shortcut would be `CMD+SHFT+P`.
+Throughout this documentation, Windows keyboard shortcuts for VS Code are frequently referenced. In general, these keyboard shortcuts work on the Mac, however, Mac users should substitute `Command` whenever `Ctrl` is referenced. For example, Windows users might use the keyboard shortcut `Ctrl+Shift+P` to open the Command Palette. On the Mac, this keyboard shortcut would be `Command+Shift+P`.
 
 ### Browser Recommendations Summary
 


### PR DESCRIPTION
Fixes #183

## Summary

adds a brief explanation in chapter 00 that Mac users should substitute CMD for CTRL when VS Code keyboard shortcuts are referenced.

## Changes


- Added a brief heading and explanation at LN445 in Chapter 00 that Mac users should substitute CMD for CTRL when VS Code Windows keyboard shortcuts are provided.


## Related Issue

<!-- Link to the issue this PR addresses. Use "Closes #N" to auto-close on merge. -->

Closes #183

## How to Review

<!-- Tell the reviewer what to focus on. What should they read first? What is in scope and out of scope? -->

## Accessibility Considerations

<!-- Did this change affect keyboard navigation, screen reader experience, heading structure, link labels, or alt text? If so, describe what you checked and what you changed. -->

- [x] Heading levels are sequential (no skipped levels)
- [x] Link text is descriptive (no "click here" or bare URLs)
- [x] Any images include meaningful alt text, or `alt=""` if decorative
- [x] No content relies on color alone to convey meaning
- [x] Keyboard navigation still works as expected

## Testing

<!-- How did you verify your changes? -->

- Tested with VoiceOver to make sure heading level is correct.
## Screenshots or Recordings

<!-- Optional. If you include images, please provide descriptive alt text. -->
