### PR TITLE
fix: add CLASSROOM_DAY2_ASSIGNMENT_URL to registration welcome comment

### DIFF
--- a/.github/workflows/registration.yml
+++ b/.github/workflows/registration.yml
@@ -699,15 +699,17 @@ jobs:
         env:
           CLASSROOM_ORG: ${{ vars.CLASSROOM_ORG }}
           DAY1_ASSIGNMENT_URL: ${{ vars.CLASSROOM_DAY1_ASSIGNMENT_URL }}
+          DAY2_ASSIGNMENT_URL: ${{ vars.CLASSROOM_DAY2_ASSIGNMENT_URL }}
           CLASSROOM_INVITE_STATUS: ${{ steps.classroom-invite.outputs.status }}
         with:
           script: |
             const org = process.env.CLASSROOM_ORG;
             const day1 = (process.env.DAY1_ASSIGNMENT_URL || '').trim();
+            const day2 = (process.env.DAY2_ASSIGNMENT_URL || '').trim();
             const inviteStatus = (process.env.CLASSROOM_INVITE_STATUS || '').trim();
 
             let classroomSection = '';
-            if (day1 || inviteStatus) {
+            if (day1 || day2 || inviteStatus) {
               const lines = ['## Classroom Access'];
 
               if (inviteStatus === 'invited') {
@@ -721,7 +723,11 @@ jobs:
               if (day1) {
                 lines.push(`- Day 1 assignment link: ${day1}`);
               }
-              lines.push('- Day 2 assignment link is released after Day 1 milestone completion.');
+              if (day2) {
+                lines.push(`- Day 2 assignment link: ${day2}`);
+              } else {
+                lines.push('- Day 2 assignment link is released after Day 1 milestone completion.');
+              }
 
               if (lines.length > 1) {
                 classroomSection = `\n\n${lines.join('\n')}`;


### PR DESCRIPTION
Fixes the two failing automation-tests.yml runs.

The registration-workflow-readiness.test.js automation test asserts that registration.yml references CLASSROOM_DAY2_ASSIGNMENT_URL. The Post welcome comment step in the welcome job was missing this variable.

This adds DAY2_ASSIGNMENT_URL to the env block and wires it into the classroom access section of the welcome comment. All 99 automation tests pass locally.