### PR TITLE
Add redirect from /github to registration page for GitHub Pages

### DIFF
--- a/github/index.html
+++ b/github/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="refresh" content="0; url=/html/REGISTER.html">
+  <title>Redirecting...</title>
+  <meta name="robots" content="noindex">
+</head>
+<body>
+  <p>If you are not redirected, <a href="/html/REGISTER.html">click here to go to the registration page</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a redirect at /github/index.html so that users visiting community-access.org/github are sent to the registration page. This is implemented using a meta refresh for GitHub Pages compatibility.