### PR TITLE
chore: switch to explicit first-issue seeding fallback

### DIFF
--- a/admin/qa-bundle/learning-room/.github/workflows/skills-progression.yml
+++ b/admin/qa-bundle/learning-room/.github/workflows/skills-progression.yml
@@ -16,8 +16,6 @@ on:
         description: "Action (check_progress, assign_next, reset)"
         required: false
         default: "check_progress"
-  create:
-    types: [repository]
 
 concurrency:
   group: skills-progression-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
@@ -164,47 +162,3 @@ jobs:
             } catch (error) {
               console.error('Error awarding achievement:', error);
             }
-
-  create-first-issue:
-    name: Create First Challenge Issue
-    runs-on: ubuntu-latest
-    if: github.event_name == 'create'
-
-    steps:
-      - name: Create First Issue
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const issueTitle = "Welcome to Your First Challenge!";
-            const issueBody = `
-            ## Your First Challenge
-            Welcome to the repository! Your first challenge is to complete the following steps:
-            - [ ] Clone this repository to your local machine.
-            - [ ] Make a small change to the README file.
-            - [ ] Commit and push your changes.
-            - [ ] Open a pull request to merge your changes.
-
-            Once you complete these steps, close this issue to unlock the next challenge!
-            `;
-
-            const { data: existingIssues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'all',
-              labels: 'first-issue',
-              per_page: 100
-            });
-
-            const alreadyExists = existingIssues.some((issue) => issue.title === issueTitle);
-            if (alreadyExists) {
-              console.log('First challenge issue already exists. Skipping creation.');
-              return;
-            }
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: issueTitle,
-              body: issueBody,
-              labels: ['challenge', 'first-issue']
-            });

--- a/learning-room/.github/workflows/skills-progression.yml
+++ b/learning-room/.github/workflows/skills-progression.yml
@@ -16,8 +16,6 @@ on:
         description: "Action (check_progress, assign_next, reset)"
         required: false
         default: "check_progress"
-  create:
-    types: [repository]
 
 concurrency:
   group: skills-progression-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
@@ -164,47 +162,3 @@ jobs:
             } catch (error) {
               console.error('Error awarding achievement:', error);
             }
-
-  create-first-issue:
-    name: Create First Challenge Issue
-    runs-on: ubuntu-latest
-    if: github.event_name == 'create'
-
-    steps:
-      - name: Create First Issue
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const issueTitle = "Welcome to Your First Challenge!";
-            const issueBody = `
-            ## Your First Challenge
-            Welcome to the repository! Your first challenge is to complete the following steps:
-            - [ ] Clone this repository to your local machine.
-            - [ ] Make a small change to the README file.
-            - [ ] Commit and push your changes.
-            - [ ] Open a pull request to merge your changes.
-
-            Once you complete these steps, close this issue to unlock the next challenge!
-            `;
-
-            const { data: existingIssues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'all',
-              labels: 'first-issue',
-              per_page: 100
-            });
-
-            const alreadyExists = existingIssues.some((issue) => issue.title === issueTitle);
-            if (alreadyExists) {
-              console.log('First challenge issue already exists. Skipping creation.');
-              return;
-            }
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: issueTitle,
-              body: issueBody,
-              labels: ['challenge', 'first-issue']
-            });

--- a/scripts/classroom/Test-LearningRoomTemplate.ps1
+++ b/scripts/classroom/Test-LearningRoomTemplate.ps1
@@ -64,33 +64,6 @@ function Get-RepositoryFileContent {
     )
 }
 
-function Wait-ForIssue {
-    param(
-        [string]$Repository,
-        [string]$TitleContains,
-        [int]$MaxAttempts = 18,
-        [int]$DelaySeconds = 5
-    )
-
-    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
-        $issues = & gh issue list -R $Repository --state all --limit 100 --json number,title
-        if ($LASTEXITCODE -eq 0 -and $issues) {
-            $parsed = $issues | ConvertFrom-Json
-            $match = @($parsed | Where-Object { $_.title -like "*$TitleContains*" }) | Select-Object -First 1
-            if ($match) {
-                return $match
-            }
-        }
-
-        if ($attempt -lt $MaxAttempts) {
-            Write-Host "Issue '$TitleContains' not found yet (attempt $attempt/$MaxAttempts). Retrying in $DelaySeconds seconds..."
-            Start-Sleep -Seconds $DelaySeconds
-        }
-    }
-
-    throw "Issue containing '$TitleContains' was not created in time for $Repository."
-}
-
 $template = "$Owner/$TemplateRepo"
 $smoke = "$Owner/$SmokeRepo"
 
@@ -122,24 +95,33 @@ try {
     Invoke-CheckedCommand gh @('api', "repos/$smoke/contents/.github/ISSUE_TEMPLATE/challenge-01-find-your-way.yml")
     Invoke-CheckedCommand gh @('api', "repos/$smoke/contents/.github/scripts/challenge-progression.js")
 
-    Write-Host "Validating skills progression workflow create trigger and first-issue job..."
+    Write-Host "Validating skills progression workflow no longer depends on create-event issue seeding..."
     $skillsWorkflow = Get-RepositoryFileContent -Repository $smoke -Path '.github/workflows/skills-progression.yml'
-    if ($skillsWorkflow -notmatch '(?m)^\s{2}create:\s*$') {
-        throw "skills-progression.yml is missing 'create' trigger."
+    if ($skillsWorkflow -match '(?m)^\s{2}create:\s*$') {
+        throw "skills-progression.yml still contains a 'create' trigger."
     }
-    if ($skillsWorkflow -notmatch '(?m)^\s{2}create-first-issue:\s*$') {
-        throw "skills-progression.yml is missing create-first-issue job."
+    if ($skillsWorkflow -match '(?m)^\s{2}create-first-issue:\s*$') {
+        throw "skills-progression.yml still contains create-first-issue job."
     }
-    if ($skillsWorkflow -notmatch '(?m)^\s{4}if:\s+github\.event_name\s*==\s*''create''\s*$') {
-        throw "create-first-issue job is missing the create-event guard condition."
-    }
-
-    Write-Host "Waiting for auto-created first challenge issue..."
-    $firstIssue = Wait-ForIssue -Repository $smoke -TitleContains 'Welcome to Your First Challenge!'
-    Write-Host "Detected first issue #$($firstIssue.number): $($firstIssue.title)"
 
     Write-Host "Triggering Challenge 1 creation..."
-    Invoke-CheckedCommand gh @('workflow', 'run', 'student-progression.yml', '-R', $smoke, '-f', 'start_challenge=1')
+    $workflowTriggered = $false
+    for ($attempt = 1; $attempt -le 12; $attempt++) {
+        & gh workflow run 'Student Progression Bot' -R $smoke -f 'start_challenge=1'
+        if ($LASTEXITCODE -eq 0) {
+            $workflowTriggered = $true
+            break
+        }
+
+        if ($attempt -lt 12) {
+            Write-Host "Student Progression Bot not ready yet (attempt $attempt/12). Retrying in 5 seconds..."
+            Start-Sleep -Seconds 5
+        }
+    }
+
+    if (-not $workflowTriggered) {
+        throw "Could not trigger Student Progression Bot in $smoke after multiple attempts."
+    }
 
     Write-Host "Smoke repo created and workflow triggered. Wait about one minute, then verify:"
     Write-Host "  gh issue list -R $smoke --search \"Challenge 1\""


### PR DESCRIPTION
## Summary\n- remove create-event first-issue automation from skills-progression workflow\n- mirror same removal in qa-bundle learning-room workflow\n- update template smoke test to validate fallback mode and robustly trigger Student Progression Bot by name\n\n## Why\nTemplate-repo create-event issue seeding proved unreliable in live smoke validation. This switches to explicit issue seeding and progression-trigger flow for predictable operations.