### PR TITLE
Hide non-active challenge templates from issue picker

### DIFF
--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/bonus-a-improve-agent.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/bonus-a-improve-agent.yml
@@ -1,5 +1,6 @@
 name: "Bonus A: Improve an Existing Agent"
 description: Fork an agent, make a meaningful improvement, and open a PR.
+hidden: true
 title: "Bonus: Improve an Existing Agent (@{username})"
 labels: ["challenge", "bonus"]
 body:
@@ -36,6 +37,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe the agent you improved, what you changed, and link your PR."
+hidden: true
       placeholder: |
         Agent I improved: ...
         What I changed: ...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/bonus-b-document-journey.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/bonus-b-document-journey.yml
@@ -1,5 +1,6 @@
 name: "Bonus B: Document Your Journey"
 description: Write a reflection document about your workshop experience.
+hidden: true
 title: "Bonus: Document Your Journey (@{username})"
 labels: ["challenge", "bonus"]
 body:
@@ -43,6 +44,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Share the link to your reflection file or PR."
+hidden: true
       placeholder: |
         Reflection URL: https://github.com/...
         My biggest takeaway: ...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/bonus-c-group-challenge.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/bonus-c-group-challenge.yml
@@ -1,5 +1,6 @@
 name: "Bonus C: Create a Group Challenge"
 description: Design a collaborative challenge for future workshop cohorts.
+hidden: true
 title: "Bonus: Create a Group Challenge (@{username})"
 labels: ["challenge", "bonus"]
 body:
@@ -39,6 +40,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe your group challenge and link to the file."
+hidden: true
       placeholder: |
         Challenge name: ...
         What teams would do: ...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/bonus-d-notifications.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/bonus-d-notifications.yml
@@ -1,5 +1,6 @@
 name: "Bonus D: Notification Mastery"
 description: Configure GitHub notifications for productive inbox management.
+hidden: true
 title: "Bonus: Notification Mastery (@{username})"
 labels: ["challenge", "bonus"]
 body:
@@ -36,6 +37,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe your notification configuration and strategy."
+hidden: true
       placeholder: |
         My notification strategy: ...
         I configured email for: ...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/bonus-e-git-history.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/bonus-e-git-history.yml
@@ -1,5 +1,6 @@
 name: "Bonus E: Explore Git History Visually"
 description: Use GitHub Desktop to explore repository history as a visual timeline.
+hidden: true
 title: "Bonus: Explore Git History Visually (@{username})"
 labels: ["challenge", "bonus"]
 body:
@@ -41,6 +42,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe what you discovered by exploring the Git history visually."
+hidden: true
       placeholder: |
         Tool I used: GitHub Desktop / GitHub.com
         Number of branches I found: ...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-01-find-your-way.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-01-find-your-way.yml
@@ -1,5 +1,6 @@
 name: "Challenge 1: Find Your Way Around"
 description: Navigate the learning-room repository and find key landmarks.
+hidden: true
 title: "Challenge 1: Find Your Way Around (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -28,6 +29,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste your scavenger hunt findings below. For each item, write a short sentence about what you found."
+hidden: true
       placeholder: |
         1. I found ___ files in the root of the repository.
         2. The open issue I found was titled "___".

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-03-conversation.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-03-conversation.yml
@@ -1,5 +1,6 @@
 name: "Challenge 3: Join the Conversation"
 description: Comment on a peer-simulation issue using @mentions and reactions.
+hidden: true
 title: "Challenge 3: Join the Conversation (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -33,6 +34,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of the comment you left on the peer-simulation issue or buddy issue."
+hidden: true
       placeholder: |
         Comment URL: https://github.com/...
         I commented on the peer-simulation issue about...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-04-branch-out.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-04-branch-out.yml
@@ -1,5 +1,6 @@
 name: "Challenge 4: Branch Out"
 description: Create your personal branch for Day 1 work.
+hidden: true
 title: "Challenge 4: Branch Out (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -34,6 +35,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Confirm your branch name and describe how you created it."
+hidden: true
       placeholder: |
         My branch name: learn/myusername
         I created it by...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-05-make-your-mark.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-05-make-your-mark.yml
@@ -1,5 +1,6 @@
 name: "Challenge 5: Make Your Mark"
 description: Edit welcome.md to fix a TODO and commit with a meaningful message.
+hidden: true
 title: "Challenge 5: Make Your Mark (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -36,6 +37,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of your commit and share your commit message."
+hidden: true
       placeholder: |
         Commit URL: https://github.com/...
         My commit message was: "..."

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-06-first-pr.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-06-first-pr.yml
@@ -1,5 +1,6 @@
 name: "Challenge 6: Open Your First Pull Request"
 description: Open a PR from your branch to main, linking it to your issue.
+hidden: true
 title: "Challenge 6: Open Your First PR (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -24,6 +25,7 @@ body:
         ### PR description template
 
         Use this structure for your PR description:
+hidden: true
 
         ```
         ## What this PR does
@@ -48,6 +50,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of your pull request."
+hidden: true
       placeholder: |
         PR URL: https://github.com/...
         My PR links to issue #...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-07-merge-conflict.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-07-merge-conflict.yml
@@ -1,5 +1,6 @@
 name: "Challenge 7: Survive a Merge Conflict"
 description: Resolve a facilitator-triggered merge conflict.
+hidden: true
 title: "Challenge 7: Survive a Merge Conflict (@{username})"
 labels: ["challenge", "day-1", "autograded"]
 body:
@@ -43,6 +44,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe the conflict and how you resolved it."
+hidden: true
       placeholder: |
         The conflict was in file: ...
         I chose to keep: ...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-08-culture.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-08-culture.yml
@@ -1,5 +1,6 @@
 name: "Challenge 8: The Culture Layer"
 description: Reflect on open source culture and triage an issue with labels.
+hidden: true
 title: "Challenge 8: The Culture Layer (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -35,6 +36,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Share your reflection and describe which issue you triaged and what label you added."
+hidden: true
       placeholder: |
         Reflection: ...
 

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-09-merge-day.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-09-merge-day.yml
@@ -1,5 +1,6 @@
 name: "Challenge 9: Merge Day"
 description: Get your Day 1 PR merged and celebrate.
+hidden: true
 title: "Challenge 9: Merge Day (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -43,6 +44,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Confirm your PR was merged and share what you accomplished today."
+hidden: true
       placeholder: |
         My PR was merged: [link]
         My issue was automatically closed: [link]

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-10-go-local.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-10-go-local.yml
@@ -1,5 +1,6 @@
 name: "Challenge 10: Go Local"
 description: Clone the repo, create a branch, edit, commit, and push from your local tool.
+hidden: true
 title: "Challenge 10: Go Local (@{username})"
 labels: ["challenge", "day-2", "autograded"]
 body:
@@ -57,6 +58,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe what tool you used, what you edited, and your commit message."
+hidden: true
       placeholder: |
         Tool used: VS Code / GitHub Desktop / CLI
         Branch name: fix/myusername

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-11-day2-pr.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-11-day2-pr.yml
@@ -1,5 +1,6 @@
 name: "Challenge 11: Open a Day 2 PR"
 description: Open a PR from your locally-pushed branch.
+hidden: true
 title: "Challenge 11: Open a Day 2 PR (@{username})"
 labels: ["challenge", "day-2"]
 body:
@@ -34,6 +35,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of your Day 2 PR and describe the pattern you noticed."
+hidden: true
       placeholder: |
         PR URL: https://github.com/...
         The pattern I noticed: ...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-12-review.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-12-review.yml
@@ -1,5 +1,6 @@
 name: "Challenge 12: Review Like a Pro"
 description: Perform a full code review of a peer-simulation PR.
+hidden: true
 title: "Challenge 12: Review Like a Pro (@{username})"
 labels: ["challenge", "day-2"]
 body:
@@ -44,6 +45,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of your review and describe what feedback you gave."
+hidden: true
       placeholder: |
         Review URL: https://github.com/...
         I reviewed the peer-simulation PR.

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-13-copilot.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-13-copilot.yml
@@ -1,5 +1,6 @@
 name: "Challenge 13: AI as Your Copilot"
 description: Use GitHub Copilot to improve documentation, then critically evaluate the output.
+hidden: true
 title: "Challenge 13: AI as Your Copilot (@{username})"
 labels: ["challenge", "day-2"]
 body:
@@ -46,6 +47,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe what you asked Copilot to do, what it suggested, and your evaluation."
+hidden: true
       placeholder: |
         I asked Copilot to: ...
         It suggested: ...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-14-template.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-14-template.yml
@@ -1,5 +1,6 @@
 name: "Challenge 14: Template Remix"
 description: Create a custom issue template by remixing the registration template.
+hidden: true
 title: "Challenge 14: Template Remix (@{username})"
 labels: ["challenge", "day-2", "autograded"]
 body:
@@ -33,6 +34,7 @@ body:
         ```yaml
         name: "Your Template Name"
         description: "One sentence describing when to use this template."
+hidden: true
         title: "[PREFIX] "
         labels: ["your-label"]
         body:
@@ -41,6 +43,7 @@ body:
             attributes:
               label: "Details"
               description: "Describe your request."
+hidden: true
             validations:
               required: true
         ```
@@ -52,6 +55,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of your template file and describe what it is for."
+hidden: true
       placeholder: |
         Template file URL: https://github.com/...
         My template is for: ...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-15-agents.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-15-agents.yml
@@ -1,5 +1,6 @@
 name: "Challenge 15: Meet the Agents"
 description: Discover accessibility agents, run one, and read one agent's instructions.
+hidden: true
 title: "Challenge 15: Meet the Agents (@{username})"
 labels: ["challenge", "day-2"]
 body:
@@ -36,6 +37,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Name 3 agents you discovered, describe one you ran, and summarize one agent's instructions."
+hidden: true
       placeholder: |
         Three agents I found:
         1. ...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-16-capstone.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/challenge-16-capstone.yml
@@ -1,5 +1,6 @@
 name: "Challenge 16: Build Your Agent (Capstone)"
 description: Fork the accessibility-agents repo, write an agent, and open a cross-fork PR.
+hidden: true
 title: "Challenge 16: Build Your Agent (@{username})"
 labels: ["challenge", "day-2", "autograded", "capstone"]
 body:
@@ -36,6 +37,7 @@ body:
         ---
         name: "Your Agent Name"
         description: "One sentence describing what your agent does."
+hidden: true
         tools: ["codebase"]
         ---
 
@@ -72,6 +74,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Share your fork URL, PR URL, and describe your agent."
+hidden: true
       placeholder: |
         My fork: https://github.com/YOUR-USERNAME/accessibility-agents
         My PR: https://github.com/Community-Access/accessibility-agents/pull/...

--- a/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/start-here-roadmap.yml
+++ b/admin/qa-bundle/learning-room/.github/ISSUE_TEMPLATE/start-here-roadmap.yml
@@ -1,5 +1,6 @@
 name: "Start Here: Student Course Roadmap"
 description: First-stop guide for students to follow setup, challenges, and support resources in order.
+hidden: true
 title: "Start Here: Student Course Roadmap (@{username})"
 labels: ["onboarding", "student"]
 body:
@@ -48,6 +49,7 @@ body:
     attributes:
       label: "Your first step"
       description: "Write the first challenge you will complete and one goal for today."
+hidden: true
       placeholder: |
         First challenge: Challenge 1
         Goal: Complete Day 1 through Challenge 3

--- a/learning-room/.github/ISSUE_TEMPLATE/bonus-a-improve-agent.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/bonus-a-improve-agent.yml
@@ -1,5 +1,6 @@
 name: "Bonus A: Improve an Existing Agent"
 description: Fork an agent, make a meaningful improvement, and open a PR.
+hidden: true
 title: "Bonus: Improve an Existing Agent (@{username})"
 labels: ["challenge", "bonus"]
 body:
@@ -36,6 +37,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe the agent you improved, what you changed, and link your PR."
+hidden: true
       placeholder: |
         Agent I improved: ...
         What I changed: ...

--- a/learning-room/.github/ISSUE_TEMPLATE/bonus-b-document-journey.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/bonus-b-document-journey.yml
@@ -1,5 +1,6 @@
 name: "Bonus B: Document Your Journey"
 description: Write a reflection document about your workshop experience.
+hidden: true
 title: "Bonus: Document Your Journey (@{username})"
 labels: ["challenge", "bonus"]
 body:
@@ -43,6 +44,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Share the link to your reflection file or PR."
+hidden: true
       placeholder: |
         Reflection URL: https://github.com/...
         My biggest takeaway: ...

--- a/learning-room/.github/ISSUE_TEMPLATE/bonus-c-group-challenge.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/bonus-c-group-challenge.yml
@@ -1,5 +1,6 @@
 name: "Bonus C: Create a Group Challenge"
 description: Design a collaborative challenge for future workshop cohorts.
+hidden: true
 title: "Bonus: Create a Group Challenge (@{username})"
 labels: ["challenge", "bonus"]
 body:
@@ -39,6 +40,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe your group challenge and link to the file."
+hidden: true
       placeholder: |
         Challenge name: ...
         What teams would do: ...

--- a/learning-room/.github/ISSUE_TEMPLATE/bonus-d-notifications.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/bonus-d-notifications.yml
@@ -1,5 +1,6 @@
 name: "Bonus D: Notification Mastery"
 description: Configure GitHub notifications for productive inbox management.
+hidden: true
 title: "Bonus: Notification Mastery (@{username})"
 labels: ["challenge", "bonus"]
 body:
@@ -36,6 +37,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe your notification configuration and strategy."
+hidden: true
       placeholder: |
         My notification strategy: ...
         I configured email for: ...

--- a/learning-room/.github/ISSUE_TEMPLATE/bonus-e-git-history.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/bonus-e-git-history.yml
@@ -1,5 +1,6 @@
 name: "Bonus E: Explore Git History Visually"
 description: Use GitHub Desktop to explore repository history as a visual timeline.
+hidden: true
 title: "Bonus: Explore Git History Visually (@{username})"
 labels: ["challenge", "bonus"]
 body:
@@ -41,6 +42,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe what you discovered by exploring the Git history visually."
+hidden: true
       placeholder: |
         Tool I used: GitHub Desktop / GitHub.com
         Number of branches I found: ...

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-01-find-your-way.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-01-find-your-way.yml
@@ -1,5 +1,6 @@
 name: "Challenge 1: Find Your Way Around"
 description: Navigate the learning-room repository and find key landmarks.
+hidden: true
 title: "Challenge 1: Find Your Way Around (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -28,6 +29,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste your scavenger hunt findings below. For each item, write a short sentence about what you found."
+hidden: true
       placeholder: |
         1. I found ___ files in the root of the repository.
         2. The open issue I found was titled "___".

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-03-conversation.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-03-conversation.yml
@@ -1,5 +1,6 @@
 name: "Challenge 3: Join the Conversation"
 description: Comment on a peer-simulation issue using @mentions and reactions.
+hidden: true
 title: "Challenge 3: Join the Conversation (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -33,6 +34,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of the comment you left on the peer-simulation issue or buddy issue."
+hidden: true
       placeholder: |
         Comment URL: https://github.com/...
         I commented on the peer-simulation issue about...

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-04-branch-out.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-04-branch-out.yml
@@ -1,5 +1,6 @@
 name: "Challenge 4: Branch Out"
 description: Create your personal branch for Day 1 work.
+hidden: true
 title: "Challenge 4: Branch Out (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -34,6 +35,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Confirm your branch name and describe how you created it."
+hidden: true
       placeholder: |
         My branch name: learn/myusername
         I created it by...

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-05-make-your-mark.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-05-make-your-mark.yml
@@ -1,5 +1,6 @@
 name: "Challenge 5: Make Your Mark"
 description: Edit welcome.md to fix a TODO and commit with a meaningful message.
+hidden: true
 title: "Challenge 5: Make Your Mark (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -36,6 +37,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of your commit and share your commit message."
+hidden: true
       placeholder: |
         Commit URL: https://github.com/...
         My commit message was: "..."

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-06-first-pr.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-06-first-pr.yml
@@ -1,5 +1,6 @@
 name: "Challenge 6: Open Your First Pull Request"
 description: Open a PR from your branch to main, linking it to your issue.
+hidden: true
 title: "Challenge 6: Open Your First PR (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -24,6 +25,7 @@ body:
         ### PR description template
 
         Use this structure for your PR description:
+hidden: true
 
         ```
         ## What this PR does
@@ -48,6 +50,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of your pull request."
+hidden: true
       placeholder: |
         PR URL: https://github.com/...
         My PR links to issue #...

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-07-merge-conflict.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-07-merge-conflict.yml
@@ -1,5 +1,6 @@
 name: "Challenge 7: Survive a Merge Conflict"
 description: Resolve a facilitator-triggered merge conflict.
+hidden: true
 title: "Challenge 7: Survive a Merge Conflict (@{username})"
 labels: ["challenge", "day-1", "autograded"]
 body:
@@ -43,6 +44,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe the conflict and how you resolved it."
+hidden: true
       placeholder: |
         The conflict was in file: ...
         I chose to keep: ...

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-08-culture.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-08-culture.yml
@@ -1,5 +1,6 @@
 name: "Challenge 8: The Culture Layer"
 description: Reflect on open source culture and triage an issue with labels.
+hidden: true
 title: "Challenge 8: The Culture Layer (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -35,6 +36,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Share your reflection and describe which issue you triaged and what label you added."
+hidden: true
       placeholder: |
         Reflection: ...
 

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-09-merge-day.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-09-merge-day.yml
@@ -1,5 +1,6 @@
 name: "Challenge 9: Merge Day"
 description: Get your Day 1 PR merged and celebrate.
+hidden: true
 title: "Challenge 9: Merge Day (@{username})"
 labels: ["challenge", "day-1"]
 body:
@@ -43,6 +44,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Confirm your PR was merged and share what you accomplished today."
+hidden: true
       placeholder: |
         My PR was merged: [link]
         My issue was automatically closed: [link]

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-10-go-local.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-10-go-local.yml
@@ -1,5 +1,6 @@
 name: "Challenge 10: Go Local"
 description: Clone the repo, create a branch, edit, commit, and push from your local tool.
+hidden: true
 title: "Challenge 10: Go Local (@{username})"
 labels: ["challenge", "day-2", "autograded"]
 body:
@@ -57,6 +58,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe what tool you used, what you edited, and your commit message."
+hidden: true
       placeholder: |
         Tool used: VS Code / GitHub Desktop / CLI
         Branch name: fix/myusername

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-11-day2-pr.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-11-day2-pr.yml
@@ -1,5 +1,6 @@
 name: "Challenge 11: Open a Day 2 PR"
 description: Open a PR from your locally-pushed branch.
+hidden: true
 title: "Challenge 11: Open a Day 2 PR (@{username})"
 labels: ["challenge", "day-2"]
 body:
@@ -34,6 +35,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of your Day 2 PR and describe the pattern you noticed."
+hidden: true
       placeholder: |
         PR URL: https://github.com/...
         The pattern I noticed: ...

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-12-review.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-12-review.yml
@@ -1,5 +1,6 @@
 name: "Challenge 12: Review Like a Pro"
 description: Perform a full code review of a peer-simulation PR.
+hidden: true
 title: "Challenge 12: Review Like a Pro (@{username})"
 labels: ["challenge", "day-2"]
 body:
@@ -44,6 +45,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of your review and describe what feedback you gave."
+hidden: true
       placeholder: |
         Review URL: https://github.com/...
         I reviewed the peer-simulation PR.

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-13-copilot.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-13-copilot.yml
@@ -1,5 +1,6 @@
 name: "Challenge 13: AI as Your Copilot"
 description: Use GitHub Copilot to improve documentation, then critically evaluate the output.
+hidden: true
 title: "Challenge 13: AI as Your Copilot (@{username})"
 labels: ["challenge", "day-2"]
 body:
@@ -46,6 +47,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Describe what you asked Copilot to do, what it suggested, and your evaluation."
+hidden: true
       placeholder: |
         I asked Copilot to: ...
         It suggested: ...

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-14-template.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-14-template.yml
@@ -1,5 +1,6 @@
 name: "Challenge 14: Template Remix"
 description: Create a custom issue template by remixing the registration template.
+hidden: true
 title: "Challenge 14: Template Remix (@{username})"
 labels: ["challenge", "day-2", "autograded"]
 body:
@@ -33,6 +34,7 @@ body:
         ```yaml
         name: "Your Template Name"
         description: "One sentence describing when to use this template."
+hidden: true
         title: "[PREFIX] "
         labels: ["your-label"]
         body:
@@ -41,6 +43,7 @@ body:
             attributes:
               label: "Details"
               description: "Describe your request."
+hidden: true
             validations:
               required: true
         ```
@@ -52,6 +55,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Paste the URL of your template file and describe what it is for."
+hidden: true
       placeholder: |
         Template file URL: https://github.com/...
         My template is for: ...

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-15-agents.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-15-agents.yml
@@ -1,5 +1,6 @@
 name: "Challenge 15: Meet the Agents"
 description: Discover accessibility agents, run one, and read one agent's instructions.
+hidden: true
 title: "Challenge 15: Meet the Agents (@{username})"
 labels: ["challenge", "day-2"]
 body:
@@ -36,6 +37,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Name 3 agents you discovered, describe one you ran, and summarize one agent's instructions."
+hidden: true
       placeholder: |
         Three agents I found:
         1. ...

--- a/learning-room/.github/ISSUE_TEMPLATE/challenge-16-capstone.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/challenge-16-capstone.yml
@@ -1,5 +1,6 @@
 name: "Challenge 16: Build Your Agent (Capstone)"
 description: Fork the accessibility-agents repo, write an agent, and open a cross-fork PR.
+hidden: true
 title: "Challenge 16: Build Your Agent (@{username})"
 labels: ["challenge", "day-2", "autograded", "capstone"]
 body:
@@ -36,6 +37,7 @@ body:
         ---
         name: "Your Agent Name"
         description: "One sentence describing what your agent does."
+hidden: true
         tools: ["codebase"]
         ---
 
@@ -72,6 +74,7 @@ body:
     attributes:
       label: "Your evidence"
       description: "Share your fork URL, PR URL, and describe your agent."
+hidden: true
       placeholder: |
         My fork: https://github.com/YOUR-USERNAME/accessibility-agents
         My PR: https://github.com/Community-Access/accessibility-agents/pull/...

--- a/learning-room/.github/ISSUE_TEMPLATE/start-here-roadmap.yml
+++ b/learning-room/.github/ISSUE_TEMPLATE/start-here-roadmap.yml
@@ -1,5 +1,6 @@
 name: "Start Here: Student Course Roadmap"
 description: First-stop guide for students to follow setup, challenges, and support resources in order.
+hidden: true
 title: "Start Here: Student Course Roadmap (@{username})"
 labels: ["onboarding", "student"]
 body:
@@ -48,6 +49,7 @@ body:
     attributes:
       label: "Your first step"
       description: "Write the first challenge you will complete and one goal for today."
+hidden: true
       placeholder: |
         First challenge: Challenge 1
         Goal: Complete Day 1 through Challenge 3


### PR DESCRIPTION
Hide all challenge/bonus templates except the current active one (Challenge 2) from the GitHub issue creation picker.

## Problem
Students creating new issues were shown a picker with 22+ templates, creating unnecessary UX friction.

## Solution  
- Add \hidden: true\ to all challenge/bonus templates except Challenge 2
- Students now only see Challenge 2 template when creating issues
- As they progress, the progression workflow will manage which template is visible

## Testing
- Template visibility hides all but Challenge 2
- Students can create issues without picker friction