### PR TITLE
fix: stabilize learning-room bots and support reset template

### DIFF
--- a/.github/workflows/learning-room-pr-bot.yml
+++ b/.github/workflows/learning-room-pr-bot.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.event_name == 'issues' && github.event.action == 'opened'
     steps:
       - name: Greet First Issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Check if first-time contributor
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {
@@ -163,7 +163,7 @@ jobs:
 
       - name: Post validation results
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -250,7 +250,7 @@ jobs:
 
       - name: Set status check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -282,7 +282,7 @@ jobs:
 
     steps:
       - name: Congratulate reviewer
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const reviewBody = [
@@ -311,8 +311,11 @@ jobs:
     if: github.event_name == 'issue_comment'
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Auto-respond to keywords
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { getAutoResponse } = require('./.github/scripts/comment-responder.js');

--- a/learning-room/.github/workflows/pr-validation-bot.yml
+++ b/learning-room/.github/workflows/pr-validation-bot.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check if first-time contributor
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {
@@ -138,7 +138,7 @@ jobs:
 
       - name: Detect challenge context
         id: challenge
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Detect which challenge this PR relates to from linked issues or branch name
@@ -172,7 +172,7 @@ jobs:
 
       - name: Post validation results
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -288,7 +288,7 @@ jobs:
           fi
 
       - name: Respond to comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { getAutoResponse } = require('./.github/scripts/comment-responder.js');

--- a/scripts/classroom/Reset-SupportHubEnvironment.ps1
+++ b/scripts/classroom/Reset-SupportHubEnvironment.ps1
@@ -148,30 +148,31 @@ contact_links:
 "@
         [IO.File]::WriteAllText((Join-Path $clonePath '.github/ISSUE_TEMPLATE/config.yml'), $issueConfig, [Text.UTF8Encoding]::new($false))
 
-        $firstResponse = @"
-name: First Response Assistant
-
-on:
-  issues:
-    types: [opened]
-
-permissions:
-  issues: write
-
-jobs:
-  first-response:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `Thanks for opening this request. A maintainer will review it within 24 to 48 hours.`
-            });
-"@
+                $firstResponse = @(
+                    'name: First Response Assistant'
+                    ''
+                    'on:'
+                    '  issues:'
+                    '    types: [opened]'
+                    ''
+                    'permissions:'
+                    '  issues: write'
+                    ''
+                    'jobs:'
+                    '  first-response:'
+                    '    runs-on: ubuntu-latest'
+                    '    steps:'
+                    '      - uses: actions/github-script@v8'
+                    '        with:'
+                    '          script: |'
+                    '            await github.rest.issues.createComment({'
+                    '              owner: context.repo.owner,'
+                    '              repo: context.repo.repo,'
+                    '              issue_number: context.issue.number,'
+                    "              body: 'Thanks for opening this request. A maintainer will review it within 24 to 48 hours.'"
+                    '            });'
+                    ''
+                ) -join "`n"
         [IO.File]::WriteAllText((Join-Path $clonePath '.github/workflows/first-response.yml'), $firstResponse, [Text.UTF8Encoding]::new($false))
 
         Invoke-CheckedCommand git @('config', 'user.name', 'accesswatch')


### PR DESCRIPTION
## Summary
- add checkout step before comment responder requires local script in learning-room-pr-bot workflow
- upgrade github-script usage in affected workflow/template paths to v8 for Node 24 readiness
- fix reset script generated first-response workflow template to emit valid quoted message body

## Why
- Recent run failed with module not found in comment responder job because repository files were not checked out.
- Support workflow failures were traced to malformed generated JavaScript body text.

## Validation
- verified no remaining unquoted support message body in touched paths
- verified responder job now checks out repository before requiring local script
- verified touched workflow/template paths use actions/github-script@v8