### PR TITLE
chore: migrate remaining workflow github-script steps to v8

### DIFF
--- a/.github/workflows/day2-release.yml
+++ b/.github/workflows/day2-release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Evaluate Day 1 completion signals and release Day 2 link
         id: day2_release_primary
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           DAY2_ASSIGNMENT_URL: ${{ vars.CLASSROOM_DAY2_ASSIGNMENT_URL }}
         with:
@@ -97,7 +97,7 @@ jobs:
 
       - name: Retry Day 2 release once if primary step failed
         if: ${{ steps.day2_release_primary.outcome == 'failure' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           DAY2_ASSIGNMENT_URL: ${{ vars.CLASSROOM_DAY2_ASSIGNMENT_URL }}
         with:

--- a/.github/workflows/learning-room-validation.yml
+++ b/.github/workflows/learning-room-validation.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Post feedback comment
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/registration.yml
+++ b/.github/workflows/registration.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Check for duplicate classroom enrollment
         id: dup-check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const username = context.payload.issue.user.login;
@@ -47,7 +47,7 @@ jobs:
 
       - name: Handle duplicate classroom enrollment
         if: steps.dup-check.outputs.is_duplicate == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           ORIGINAL_ISSUE: ${{ steps.dup-check.outputs.original_issue }}
           DAY1_ASSIGNMENT_URL: ${{ vars.CLASSROOM_DAY1_ASSIGNMENT_URL }}
@@ -109,7 +109,7 @@ jobs:
       - name: Guardrail - validate private storage configuration
         id: storage-guardrail
         if: steps.dup-check.outputs.is_duplicate == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PRIVATE_STUDENT_DATA_REPO: ${{ vars.PRIVATE_STUDENT_DATA_REPO }}
           PRIVATE_STUDENT_DATA_TOKEN: ${{ secrets.PRIVATE_STUDENT_DATA_TOKEN }}
@@ -134,7 +134,7 @@ jobs:
         if: >-
           steps.dup-check.outputs.is_duplicate == 'false' &&
           steps.storage-guardrail.outputs.configured == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           MISSING_CONFIG: ${{ steps.storage-guardrail.outputs.missing }}
         with:
@@ -194,7 +194,7 @@ jobs:
         if: >-
           steps.dup-check.outputs.is_duplicate == 'false' &&
           steps.storage-guardrail.outputs.configured == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             function parseField(body, fieldName) {
@@ -229,7 +229,7 @@ jobs:
           steps.dup-check.outputs.is_duplicate == 'false' &&
           steps.storage-guardrail.outputs.configured == 'true' &&
           steps.parse.outputs.is_valid == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           MISSING_FIELDS: ${{ steps.parse.outputs.missing_fields }}
         with:
@@ -274,7 +274,7 @@ jobs:
           steps.storage-guardrail.outputs.configured == 'true' &&
           steps.parse.outputs.is_valid == 'true' &&
           vars.PRIVATE_STUDENT_DATA_REPO != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           TARGET_REPO: ${{ vars.PRIVATE_STUDENT_DATA_REPO }}
           FULL_NAME: ${{ steps.parse.outputs.full_name }}
@@ -332,7 +332,7 @@ jobs:
           steps.dup-check.outputs.is_duplicate == 'false' &&
           steps.storage-guardrail.outputs.configured == 'true' &&
           steps.parse.outputs.is_valid == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.update({
@@ -353,7 +353,7 @@ jobs:
           steps.dup-check.outputs.is_duplicate == 'false' &&
           steps.storage-guardrail.outputs.configured == 'true' &&
           steps.parse.outputs.is_valid == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           DAY1_ASSIGNMENT_URL: ${{ vars.CLASSROOM_DAY1_ASSIGNMENT_URL }}
         with:
@@ -413,7 +413,7 @@ jobs:
           steps.dup-check.outputs.is_duplicate == 'false' &&
           steps.storage-guardrail.outputs.configured == 'true' &&
           steps.parse.outputs.is_valid == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.addLabels({
@@ -428,7 +428,7 @@ jobs:
           steps.dup-check.outputs.is_duplicate == 'false' &&
           steps.storage-guardrail.outputs.configured == 'true' &&
           steps.parse.outputs.is_valid == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             function extractProficiencyLabel(body, field) {
@@ -465,7 +465,7 @@ jobs:
     steps:
       - name: Check for duplicate registration
         id: dup-check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const username = context.payload.issue.user.login;
@@ -493,7 +493,7 @@ jobs:
 
       - name: Handle duplicate registration
         if: steps.dup-check.outputs.is_duplicate == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           ORIGINAL_ISSUE: ${{ steps.dup-check.outputs.original_issue }}
         with:
@@ -546,7 +546,7 @@ jobs:
       - name: Check capacity
         id: capacity-check
         if: steps.dup-check.outputs.is_duplicate == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Count unique registered users (excluding this issue)
@@ -573,7 +573,7 @@ jobs:
 
       - name: Handle registration full
         if: steps.dup-check.outputs.is_duplicate == 'false' && steps.capacity-check.outputs.is_full == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             function parseField(body, fieldName) {
@@ -613,7 +613,7 @@ jobs:
 
       - name: Post welcome comment
         if: steps.dup-check.outputs.is_duplicate == 'false' && steps.capacity-check.outputs.is_full == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           DAY1_ASSIGNMENT_URL: ${{ vars.CLASSROOM_DAY1_ASSIGNMENT_URL }}
           DAY2_ASSIGNMENT_URL: ${{ vars.CLASSROOM_DAY2_ASSIGNMENT_URL }}
@@ -670,7 +670,7 @@ jobs:
 
       - name: Add registration label
         if: steps.dup-check.outputs.is_duplicate == 'false' && steps.capacity-check.outputs.is_full == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {
@@ -695,7 +695,7 @@ jobs:
       vars.ENABLE_PUBLIC_REGISTRATION_EXPORT == 'true'
     steps:
       - name: Generate CSV from registration issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -819,7 +819,7 @@ jobs:
       vars.ENABLE_PUBLIC_CLASSROOM_INTAKE_EXPORT == 'true'
     steps:
       - name: Generate CSV from classroom enrollment issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -904,7 +904,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build roster from registration issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/skills-progression.yml
+++ b/.github/workflows/skills-progression.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: '20'
 
       - name: Record completion
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {
@@ -152,7 +152,7 @@ jobs:
           node-version: '20'
 
       - name: Check for next challenge
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -288,7 +288,7 @@ jobs:
     
     steps:
       - name: Check for milestones
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const student = context.payload.pull_request.user.login;

--- a/.github/workflows/student-grouping.yml
+++ b/.github/workflows/student-grouping.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: '20'
 
       - name: Find and assign peer reviewer
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -225,7 +225,7 @@ jobs:
           node-version: '20'
 
       - name: Create balanced groups
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary
- upgrade remaining actions/github-script workflow usages from v7 to v8
- apply updates in day2-release, registration, learning-room-validation, skills-progression, and student-grouping workflows

## Why
GitHub Actions runners are deprecating Node 20 for JavaScript actions. Upgrading to v8 aligns these workflows with Node 24 support.

## Validation
- searched target workflows to confirm no remaining actions/github-script@v7 references