### PR TITLE
chore: migrate classroom template sources to github-script v8

### DIFF
--- a/classroom/student-progression.yml
+++ b/classroom/student-progression.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Unlock Next Step
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const eventName = context.eventName;

--- a/scripts/classroom/Add-AutograderSafeguards.ps1
+++ b/scripts/classroom/Add-AutograderSafeguards.ps1
@@ -186,7 +186,7 @@ if ($tpl -notmatch 'Post workflow error notice') {
         $lf +
         '      - name: Post workflow error notice' + $lf +
         '        if: failure()' + $lf +
-        '        uses: actions/github-script@v7' + $lf +
+        '        uses: actions/github-script@v8' + $lf +
         '        with:' + $lf +
         '          script: |' + $lf +
         "            const MARKER = '## Challenge 14:';" + $lf +
@@ -316,7 +316,7 @@ jobs:
 
     steps:
       - name: Find PR and post notice if needed
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const run = context.payload.workflow_run;

--- a/scripts/classroom/Fix-AutograderComments.ps1
+++ b/scripts/classroom/Fix-AutograderComments.ps1
@@ -91,7 +91,7 @@ foreach ($c in $challenges) {
             $lf +
             '      - name: Post workflow error notice' + $lf +
             '        if: failure()' + $lf +
-            '        uses: actions/github-script@v7' + $lf +
+            '        uses: actions/github-script@v8' + $lf +
             '        with:' + $lf +
             '          script: |' + $lf +
             "            const MARKER = '## Challenge " + $num + ":';" + $lf +


### PR DESCRIPTION
## Summary
- update classroom student workflow template to actions/github-script@v8
- update autograder remediation scripts to emit actions/github-script@v8

## Why
Template and generator sources can reintroduce v7 into downstream repos even after workflow files are upgraded.

## Validation
- searched these files and confirmed no remaining actions/github-script@v7 references