### PR TITLE
fix(enrollment): guide learners who submit the wrong template out of the trap

### DIFF
--- a/.github/ISSUE_TEMPLATE/start-here-roadmap.yml
+++ b/.github/ISSUE_TEMPLATE/start-here-roadmap.yml
@@ -1,5 +1,5 @@
-name: "Start Here: Student Course Roadmap"
-description: First-stop guide for students to follow setup, challenges, and support resources in order.
+name: "Course Roadmap Check-In (already enrolled students)"
+description: For students who already have a learning room. Enrolling? Use "Workshop Enrollment - New Student Fast Path" instead.
 title: "Start Here: Student Course Roadmap (@{username})"
 labels: ["onboarding", "student"]
 body:
@@ -7,6 +7,10 @@ body:
     attributes:
       value: |
         ## Start Here: Student Course Roadmap
+
+        > **Not enrolled yet?** This form does not enroll you. Use the
+        > [Workshop Enrollment form](https://github.com/Community-Access/git-going-with-github/issues/new?template=enrollment.yml&title=%5BENROLL%5D+GIT+Going+with+GitHub)
+        > instead - it asks for your name and email and creates your private learning room.
 
         Use this issue as your launch point for the full workshop path.
 

--- a/.github/workflows/learning-room-pr-bot.yml
+++ b/.github/workflows/learning-room-pr-bot.yml
@@ -23,7 +23,13 @@ jobs:
   welcome-issue-timer:
     name: Welcome to Your First Issue
     runs-on: ubuntu-latest
-    if: github.event_name == 'issues' && github.event.action == 'opened'
+    # Skip intake issues (enrollment/registration): those get their own
+    # automation comments, and a "first issue" greeting there confuses
+    # brand-new learners mid-signup.
+    if: >-
+      github.event_name == 'issues' && github.event.action == 'opened' &&
+      !startsWith(github.event.issue.title, '[ENROLL]') &&
+      !startsWith(github.event.issue.title, '[REGISTER]')
     steps:
       - name: Greet First Issue
         uses: actions/github-script@v8

--- a/.github/workflows/registration.yml
+++ b/.github/workflows/registration.yml
@@ -247,7 +247,25 @@ jobs:
               '',
               `Hi ${displayName}, we could not process enrollment because some required values were missing: ${process.env.MISSING_FIELDS}.`,
               '',
-              'Please edit this issue and add the missing information, then comment `ready` so a facilitator can retry.'
+              'This usually happens when the issue was created from a different template than the enrollment form, so the name and email questions never appeared.',
+              '',
+              '**Easiest fix:** edit this issue and paste the lines below at the top of the issue body, filling in your details:',
+              '',
+              '```markdown',
+              '### Full Name',
+              '',
+              'Your Name Here',
+              '',
+              '### Email Address',
+              '',
+              'you@example.com',
+              '```',
+              '',
+              'To edit: open this issue, find the **Edit** option on the first post (in the `...` menu at the top right of the post), make the change, and select **Update comment**.',
+              '',
+              'When you are done, comment `ready` so a facilitator can retry.',
+              '',
+              'Prefer to start over instead? Use the enrollment form directly: https://github.com/Community-Access/git-going-with-github/issues/new?template=enrollment.yml&title=%5BENROLL%5D+GIT+Going+with+GitHub'
             ];
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
A learner clicked the enrollment link but submitted the Start Here roadmap
template (issue #237): the [ENROLL] title from the URL survived, the body
had the readiness checklist but no Full Name or Email Address fields, and
the needs-info bot told them to 'edit this issue and add the missing
information' without saying how. They also got the Gandalf first-issue
greeting mid-signup, which read as noise.

- registration.yml: the needs-info comment now explains the wrong-template
  cause, gives a copy-paste markdown block for the missing fields, spells
  out how to edit an issue body, and links the real enrollment form.
- learning-room-pr-bot.yml: the first-issue greeting skips [ENROLL] and
  [REGISTER] intake issues.
- start-here-roadmap.yml (main repo chooser only; learning-room copy
  unchanged): renamed to 'Course Roadmap Check-In (already enrolled
  students)' with an explicit not-an-enrollment warning and a link to the
  enrollment form.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
