### PR TITLE
fix(autograder): never grade seeded workshop issues as Challenge 2 submissions

### DIFF
--- a/learning-room/.github/workflows/autograder-issue-filed.yml
+++ b/learning-room/.github/workflows/autograder-issue-filed.yml
@@ -20,8 +20,18 @@ jobs:
   acknowledge-issue:
     name: Acknowledge first issue
     runs-on: ubuntu-latest
-    # Only react when the author is the student (not a bot or facilitator pre-seeded issue).
-    if: github.event_name == 'workflow_dispatch' || (github.event.issue.user.login == github.actor && github.event.issue.user.type == 'User')
+    # Only react when the author is the student (not a bot or facilitator
+    # pre-seeded issue), and never grade seeded workshop artifacts: peer
+    # simulation issues, challenge issues, and the onboarding roadmap are
+    # created by automation or facilitators, not Challenge 2 submissions.
+    if: >-
+      github.event_name == 'workflow_dispatch' || (
+        github.event.issue.user.login == github.actor &&
+        github.event.issue.user.type == 'User' &&
+        !startsWith(github.event.issue.title, 'Peer Simulation:') &&
+        !startsWith(github.event.issue.title, 'Challenge ') &&
+        !startsWith(github.event.issue.title, 'Start Here:')
+      )
 
     steps:
       - name: Count issues authored by this student


### PR DESCRIPTION
The Challenge 2 issue-filed autograder only guarded on author == actor,
so peer simulation issues seeded with a user token (and any future
App-token seeding, which also triggers workflows) got flagged with
challenge-2-needs-revision labels and a Needs revision comment. Skip
issues titled Peer Simulation:, Challenge, or Start Here: - those are
workshop artifacts, not student submissions. The mislabels and comments
this caused in the 8 cohort rooms have been cleaned up in place.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
